### PR TITLE
Fixed typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var elixir = require('laravel-elixir');
 require('laravel-elixir-mocha');
 
 elixir(function(mix) {
-    mix.phpcs([
+    mix.mocha([
       'tests/**/*Spec.js'
     ], {
       reporter: 'nyan'


### PR DESCRIPTION
You forgot to change the function name to `mocha`.
